### PR TITLE
Prevent multiple script loads

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import BetterArguments from '@krisell/better-arguments'
 
+const loadStates = {}
+
 const DOM = {
   /**
    * Creates a DOM-element with tag and class set in
@@ -90,15 +92,26 @@ const DOM = {
    * Loads a script dynamically and returns a promise which
    * resolves when the script has been loaded.
    */
-  loadScript (src) {
+  loadScript (src, options = {}) {
+    const forceLoad = options.force === true
+    const skipLoad = loadStates[src] === 'pending' || loadStates[src] === 'success'
+    
+    if (skipLoad && !forceLoad) {
+      return Promise.resolve()
+    }
+    
+    loadStates[src] = 'pending'
+    
     let script = document.createElement('script')
 
     return new Promise((resolve, reject) => {
       script.onload = function () {
+        loadStates[src] = 'success'
         resolve()
       }
 
       script.onerror = function () {
+        loadStates[src] = 'error'
         reject(new Error('Script load error'))
       }
 


### PR DESCRIPTION
Added simple state machine for DOM.loadScript and prevent additional loads for the same script if state is ```success``` or ```pending```.
Extended parameters with an additional optional options object if script loads should be force-loaded even if it's been loaded before.